### PR TITLE
Add support for multi-segment clue navigation to arrow keys

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+    "singleQuote": true,
+    "overrides": [
+        {
+            "files": ["**/*.css", "**/*.scss", "**/*.html", "**/*.js"],
+            "options": {
+                "singleQuote": false
+            }
+        }
+    ]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,9 +2,10 @@
     "singleQuote": true,
     "overrides": [
         {
-            "files": ["**/*.css", "**/*.scss", "**/*.html", "**/*.js"],
+            "files": ["**/*.js"],
             "options": {
-                "singleQuote": false
+                "singleQuote": false,
+                "trailingComma": "all"
             }
         }
     ]

--- a/docs/crossworddefinition.md
+++ b/docs/crossworddefinition.md
@@ -1,8 +1,10 @@
+## Index <!-- omit from toc -->
 
-- [CrosswordDefinition](#crossworddefinition)
-- [Clue](#clue)
-- [Sample](#sample)
-
+* [CrosswordDefinition](#crossworddefinition)
+* [Clue](#clue)
+  * [Multi-word and multi-segment](#multi-word-and-multi-segment)
+  * [Multi-segment clue](#multi-segment-clue)
+* [Sample](#sample)
 
 ## CrosswordDefinition
 
@@ -13,8 +15,8 @@ It MUST have the following properties:
 
 - **width**: The width of the crossword *(the number of columns)*.
 - **height**: The height of the crossword *(the number of rows)*.
-- **acrossClues**: An array of [Clue][1] objects which go *across* the puzzle.
-- **downClues**: An array of [Clue][1] objects which go *down* the puzzle.
+- **acrossClues**: An array of [Clue][1] objects which go _across_ the puzzle.
+- **downClues**: An array of [Clue][1] objects which go _down_ the puzzle.
 
 It MAY have the following properties
 
@@ -25,15 +27,41 @@ It MAY have the following properties
 A **Clue** has the following properties:
 
 - **x**: The column number (1-based) of the first letter(cell) in a clue.
-- **y**: The row number (1-based) of the first letter in a clue
-- **clue**: The clue text.This structured text is composed of: 
-  - **number**: The clue number, such as `16.`
+- **y**: The row number (1-based) of the first letter in a clue.
+- **clue**: The clue text.This structured text is composed of:
+  - **number**:
+    - The clue number, such as `16.` or for a [multi-segment][3] clue `4,21.`
+    - The number MUST be terminated by a period.
   - **text**: The text of the clue, such as `Outside port finally, make fast a vessel – one that's engine driven`
-  - **length**: The length of the answer, an array such as `(6)` or `(5,4)`.
+  - **length**: The length of the answer, an array such as `(6)` or for a [multi-word][4] answer `(5,4)`.
+
+### Multi-word and multi-segment
+
+- **Multi-word** answers and **multi-segment** clues are distinct concepts.  
+- *Mult-word* answers occupy a *single* clue on the crossword grid. The clue-word separators may be styled separately to a typical clue-cell separator.  
+- *Multi-segment* clues occupy *two or more* clues on the crossword grid - one clue per segment. Segments MAY also be *multi-word* answers. 
+
+### Multi-segment clue
+
+A **mult-segment** clue:
+
+- A collection of 1+ clues on the crossword grid and in the clue lists.
+- Clue segments in the collection need not be sequential.
+- Each segment direction is either *across* or *down*.
+- The collection contain 0+ segments of both directions.
+- The order of segments in a collection is not constrained.
+- The first segment in a multi-segment will be referred to as the **anchor** clue.
+- The *number* property of the *anchor* clue is an ordered, comma-separated, list of the all the segments in the clue, e.g `4,21.`
+> BUG: There is no guarantee across and down clue numbers are distinct sets with no intersection. Perhaps we should include an `a` or `d` suffix to the clue number where ambiguity exists?
+- The *length* property of *every* segment clue, including the anchor clue, refers to the length of the answer for *only* that segment.
+- The *length* property of every segment may indicate a single-word answer or a *multi-word* answer.
 
 ## Sample
 
 A [sample file][2] can be found in the sample folder
 
 [1]: #clue
-[2]: ../sample/crosswords/albreich_4.json
+[2]: ../sample/crosswords/albreich*4.json
+[3]: #multi-segment-clue
+[4]: #multi-word-and-multi-segment
+

--- a/src/compile-clue.js
+++ b/src/compile-clue.js
@@ -17,16 +17,19 @@ function directionFromClueLabel(clueLabel) {
  */
 function compileClue(clueDefinition) {
   if (!clueDefinition) {
-    throw new Error('\'clue\' is required');
+    throw new Error("'clue' is required");
   }
 
   //  First, validate the clue structure.
   if (!clueRegex.test(clueDefinition)) {
-    throw new Error(`Clue '${clueDefinition}' does not meet the required structured '<Number>. Clue Text (<Answer structure>)'`);
+    throw new Error(
+      `Clue '${clueDefinition}' does not meet the required structured '<Number>. Clue Text (<Answer structure>)'`
+    );
   }
 
   //  Get the clue components.
-  const [, numberText, connectedCluesText, clueText, answerText] = clueRegex.exec(clueDefinition);
+  const [, numberText, connectedCluesText, clueText, answerText] =
+    clueRegex.exec(clueDefinition);
   const number = parseInt(numberText, 10);
 
   //  If we have connected clues, break them apart.
@@ -43,16 +46,23 @@ function compileClue(clueDefinition) {
   const answerSegmentRegex = /([\d]+)([,-]?)(.*)/;
   let remainingAnswerStructure = answerText;
   while (answerSegmentRegex.test(remainingAnswerStructure)) {
-    const [, length, terminator, rest] = answerSegmentRegex.exec(remainingAnswerStructure);
+    const [, length, terminator, rest] = answerSegmentRegex.exec(
+      remainingAnswerStructure
+    );
     answerStructure.push({ length: parseInt(length, 10), terminator });
     remainingAnswerStructure = rest;
   }
 
   //  Calculate the total length of the answer.
-  const totalLength = answerStructure.reduce((current, as) => current + as.length, 0);
+  const totalLength = answerStructure.reduce(
+    (current, as) => current + as.length,
+    0
+  );
 
   //  Also create the answer structure as text.
-  const answerStructureText = `(${answerStructure.map((as) => `${as.length}${as.terminator}`).join('')})`;
+  const answerStructureText = `(${answerStructure
+    .map((as) => `${as.length}${as.terminator}`)
+    .join('')})`;
 
   return {
     number,

--- a/src/compile-clue.js
+++ b/src/compile-clue.js
@@ -3,8 +3,8 @@
 const clueRegex = /^(\d+),?([\dad,]*).[\s]*(.*)[\s]*\(([\d,-]+)\)$/;
 
 function directionFromClueLabel(clueLabel) {
-  if (/a$/.test(clueLabel)) return 'across';
-  if (/d$/.test(clueLabel)) return 'down';
+  if (/a$/.test(clueLabel)) return "across";
+  if (/d$/.test(clueLabel)) return "down";
   return null;
 }
 
@@ -23,7 +23,7 @@ function compileClue(clueDefinition) {
   //  First, validate the clue structure.
   if (!clueRegex.test(clueDefinition)) {
     throw new Error(
-      `Clue '${clueDefinition}' does not meet the required structured '<Number>. Clue Text (<Answer structure>)'`
+      `Clue "${clueDefinition}" does not meet the required structured "<Number>. Clue Text (<Answer structure>)"`,
     );
   }
 
@@ -35,7 +35,7 @@ function compileClue(clueDefinition) {
   //  If we have connected clues, break them apart.
   let connectedClueNumbers = null;
   if (connectedCluesText) {
-    connectedClueNumbers = connectedCluesText.split(',').map((cc) => ({
+    connectedClueNumbers = connectedCluesText.split(",").map((cc) => ({
       number: parseInt(cc, 10),
       direction: directionFromClueLabel(cc),
     }));
@@ -47,7 +47,7 @@ function compileClue(clueDefinition) {
   let remainingAnswerStructure = answerText;
   while (answerSegmentRegex.test(remainingAnswerStructure)) {
     const [, length, terminator, rest] = answerSegmentRegex.exec(
-      remainingAnswerStructure
+      remainingAnswerStructure,
     );
     answerStructure.push({ length: parseInt(length, 10), terminator });
     remainingAnswerStructure = rest;
@@ -56,13 +56,13 @@ function compileClue(clueDefinition) {
   //  Calculate the total length of the answer.
   const totalLength = answerStructure.reduce(
     (current, as) => current + as.length,
-    0
+    0,
   );
 
   //  Also create the answer structure as text.
   const answerStructureText = `(${answerStructure
     .map((as) => `${as.length}${as.terminator}`)
-    .join('')})`;
+    .join("")})`;
 
   return {
     number,

--- a/src/compile-clue.specs.js
+++ b/src/compile-clue.specs.js
@@ -1,65 +1,83 @@
-const { expect } = require('chai');
-const compileClue = require('./compile-clue');
+const { expect } = require("chai");
+const compileClue = require("./compile-clue");
 
 //  Clues should look like this:
 //    "<Number>. Clue Text (<Answer structure>)"
 
-describe('compileClue', () => {
-  it('should fail if no clue is provided', () => {
-    expect(() => { compileClue(); }).to.throw('\'clue\' is required');
+describe("compileClue", () => {
+  it("should fail if no clue is provided", () => {
+    expect(() => {
+      compileClue();
+    }).to.throw("'clue' is required");
   });
 
-  it('should fail if the clue number is not provided', () => {
-    expect(() => { compileClue('Red or green fruit (5)'); }).to.throw('Clue \'Red or green fruit (5)\' does not meet the required structured \'<Number>. Clue Text (<Answer structure>)\'');
+  it("should fail if the clue number is not provided", () => {
+    expect(() => {
+      compileClue("Red or green fruit (5)");
+    }).to.throw(
+      "Clue 'Red or green fruit (5)' does not meet the required structured '<Number>. Clue Text (<Answer structure>)'"
+    );
   });
 
-  it('should fail if the clue number is not numeric', () => {
-    expect(() => { compileClue('a. Red or green fruit (5)'); }).to.throw('Clue \'a. Red or green fruit (5)\' does not meet the required structured \'<Number>. Clue Text (<Answer structure>)\'');
+  it("should fail if the clue number is not numeric", () => {
+    expect(() => {
+      compileClue("a. Red or green fruit (5)");
+    }).to.throw(
+      "Clue 'a. Red or green fruit (5)' does not meet the required structured '<Number>. Clue Text (<Answer structure>)'"
+    );
   });
 
-  it('should fail if the answer structure is not provided', () => {
-    expect(() => { compileClue('3. Red or green fruit'); }).to.throw('Clue \'3. Red or green fruit\' does not meet the required structured \'<Number>. Clue Text (<Answer structure>)\'');
+  it("should fail if the answer structure is not provided", () => {
+    expect(() => {
+      compileClue("3. Red or green fruit");
+    }).to.throw(
+      "Clue '3. Red or green fruit' does not meet the required structured '<Number>. Clue Text (<Answer structure>)'"
+    );
   });
 
-  it('should fail if the answer structure is not numeric', () => {
-    expect(() => { compileClue('3. Red or green fruit (a)'); }).to.throw('Clue \'3. Red or green fruit (a)\' does not meet the required structured \'<Number>. Clue Text (<Answer structure>)\'');
+  it("should fail if the answer structure is not numeric", () => {
+    expect(() => {
+      compileClue("3. Red or green fruit (a)");
+    }).to.throw(
+      "Clue '3. Red or green fruit (a)' does not meet the required structured '<Number>. Clue Text (<Answer structure>)'"
+    );
   });
 
-  it('should compile the number and answer lengths of a clue string', () => {
-    const clueModel = compileClue('3. Red or green fruit (5)');
+  it("should compile the number and answer lengths of a clue string", () => {
+    const clueModel = compileClue("3. Red or green fruit (5)");
     expect(clueModel.number).to.eql(3);
-    expect(clueModel.clueText).to.eql('Red or green fruit ');
+    expect(clueModel.clueText).to.eql("Red or green fruit ");
     expect(clueModel.totalLength).to.eql(5);
-    expect(clueModel.answerStructure).to.eql([{ length: 5, terminator: '' }]);
-    expect(clueModel.answerStructureText).to.eql('(5)');
+    expect(clueModel.answerStructure).to.eql([{ length: 5, terminator: "" }]);
+    expect(clueModel.answerStructureText).to.eql("(5)");
   });
 
-  it('should compile the answer structure', () => {
-    const clueModel = compileClue('9. Clue (5,3-4)');
+  it("should compile the answer structure", () => {
+    const clueModel = compileClue("9. Clue (5,3-4)");
     expect(clueModel.number).to.eql(9);
-    expect(clueModel.clueText).to.eql('Clue ');
+    expect(clueModel.clueText).to.eql("Clue ");
     expect(clueModel.totalLength).to.eql(12);
     expect(clueModel.answerStructure).to.eql([
-      { length: 5, terminator: ',' },
-      { length: 3, terminator: '-' },
-      { length: 4, terminator: '' },
+      { length: 5, terminator: "," },
+      { length: 3, terminator: "-" },
+      { length: 4, terminator: "" },
     ]);
-    expect(clueModel.answerStructureText).to.eql('(5,3-4)');
+    expect(clueModel.answerStructureText).to.eql("(5,3-4)");
   });
 
-  it('should compile the connected clue numbers', () => {
-    const clueModel = compileClue('9,3a,4. Clue (5,3-4)');
+  it("should compile the connected clue numbers", () => {
+    const clueModel = compileClue("9,3a,4. Clue (5,3-4)");
     expect(clueModel.number).to.eql(9);
-    expect(clueModel.clueText).to.eql('Clue ');
+    expect(clueModel.clueText).to.eql("Clue ");
     expect(clueModel.totalLength).to.eql(12);
     expect(clueModel.answerStructure).to.eql([
-      { length: 5, terminator: ',' },
-      { length: 3, terminator: '-' },
-      { length: 4, terminator: '' },
+      { length: 5, terminator: "," },
+      { length: 3, terminator: "-" },
+      { length: 4, terminator: "" },
     ]);
-    expect(clueModel.answerStructureText).to.eql('(5,3-4)');
+    expect(clueModel.answerStructureText).to.eql("(5,3-4)");
     expect(clueModel.connectedClueNumbers).to.eql([
-      { number: 3, direction: 'across' },
+      { number: 3, direction: "across" },
       { number: 4, direction: null },
     ]);
   });

--- a/src/compile-crossword.js
+++ b/src/compile-crossword.js
@@ -34,7 +34,7 @@ function getAnswerSegment(answerStructure, letterIndex) {
 function compileCrossword(crosswordDefinition) {
   if (!crosswordDefinition) {
     throw new Error(
-      "The Crossword must be initialised with a crossword definition."
+      "The Crossword must be initialised with a crossword definition.",
     );
   }
 
@@ -65,7 +65,7 @@ function compileCrossword(crosswordDefinition) {
 
   //  We're going to go through the across clues, then the down clues.
   const clueDefinitions = crosswordDefinition.acrossClues.concat(
-    crosswordDefinition.downClues
+    crosswordDefinition.downClues,
   );
   for (let c = 0; c < clueDefinitions.length; c += 1) {
     //  Grab the clue and build a flag letting us know if we're across or down.
@@ -119,7 +119,7 @@ function compileCrossword(crosswordDefinition) {
       //  Check if we need to add an answer terminator.
       const [segment, index] = getAnswerSegment(
         clueModel.answerStructure,
-        letter
+        letter,
       );
       if (index === segment.length - 1 && segment.terminator !== "") {
         cell[clueModel.across ? "acrossTerminator" : "downTerminator"] =
@@ -139,7 +139,7 @@ function compileCrossword(crosswordDefinition) {
               y + 1
             }) is not coherent with previous clue (${
               cell.acrossClue.code
-            }) answer.`
+            }) answer.`,
           );
         }
         cell.answer = clueModel.answer[letter];
@@ -148,7 +148,7 @@ function compileCrossword(crosswordDefinition) {
       if (letter === 0) {
         if (cell.clueLabel && cell.clueLabel !== clueModel.number) {
           throw new Error(
-            `Clue ${clueModel.code} has a label which is inconsistent with another clue (${cell.acrossClue.code}).`
+            `Clue ${clueModel.code} has a label which is inconsistent with another clue (${cell.acrossClue.code}).`,
           );
         }
         cell.clueLabel = clueModel.number;
@@ -173,7 +173,7 @@ function compileCrossword(crosswordDefinition) {
     clue.connectedClues = clue.connectedClueNumbers.map((connectedClue) => {
       if (connectedClue.direction === "across") {
         return model.acrossClues.find(
-          (ac) => ac.number === connectedClue.number
+          (ac) => ac.number === connectedClue.number,
         );
       }
       if (connectedClue.direction === "down") {

--- a/src/compile-crossword.js
+++ b/src/compile-crossword.js
@@ -1,4 +1,4 @@
-const compileClue = require('./compile-clue');
+const compileClue = require("./compile-clue");
 
 function buildCellArray2D(crosswordModel) {
   const x = crosswordModel.width;
@@ -33,7 +33,9 @@ function getAnswerSegment(answerStructure, letterIndex) {
 //  and options, this is the object which is returned.
 function compileCrossword(crosswordDefinition) {
   if (!crosswordDefinition) {
-    throw new Error('The Crossword must be initialised with a crossword definition.');
+    throw new Error(
+      "The Crossword must be initialised with a crossword definition."
+    );
   }
 
   //  Create the basic model structure.
@@ -46,9 +48,15 @@ function compileCrossword(crosswordDefinition) {
   };
 
   //  Validate the bounds.
-  if (model.width === undefined || model.width === null || model.width < 0
-      || model.height === undefined || model.height === null || model.height < 0) {
-    throw new Error('The crossword bounds are invalid.');
+  if (
+    model.width === undefined ||
+    model.width === null ||
+    model.width < 0 ||
+    model.height === undefined ||
+    model.height === null ||
+    model.height < 0
+  ) {
+    throw new Error("The crossword bounds are invalid.");
   }
 
   //  Create the array of cells. Each element has a refence back to the model
@@ -56,7 +64,9 @@ function compileCrossword(crosswordDefinition) {
   model.cells = buildCellArray2D(model);
 
   //  We're going to go through the across clues, then the down clues.
-  const clueDefinitions = crosswordDefinition.acrossClues.concat(crosswordDefinition.downClues);
+  const clueDefinitions = crosswordDefinition.acrossClues.concat(
+    crosswordDefinition.downClues
+  );
   for (let c = 0; c < clueDefinitions.length; c += 1) {
     //  Grab the clue and build a flag letting us know if we're across or down.
     const clueDefinition = clueDefinitions[c];
@@ -67,27 +77,31 @@ function compileCrossword(crosswordDefinition) {
 
     //  TODO: extract this into the clueCompile function.
     //  Update the clue model.
-    clueModel.code = clueModel.number + (across ? 'a' : 'd');
+    clueModel.code = clueModel.number + (across ? "a" : "d");
     clueModel.answer = clueDefinition.answer;
     clueModel.x = clueDefinition.x - 1; //  Definitions are 1 based, models are more useful 0 based.
     clueModel.y = clueDefinition.y - 1;
     clueModel.across = across;
     clueModel.cells = [];
     clueModel.clueLabel = `${clueModel.number}.`;
-    model[across ? 'acrossClues' : 'downClues'].push(clueModel);
+    model[across ? "acrossClues" : "downClues"].push(clueModel);
 
     //  The clue position must be in the bounds.
-    if (clueModel.x < 0 || clueModel.x >= model.width
-      || clueModel.y < 0 || clueModel.y >= model.height) {
+    if (
+      clueModel.x < 0 ||
+      clueModel.x >= model.width ||
+      clueModel.y < 0 ||
+      clueModel.y >= model.height
+    ) {
       throw new Error(`Clue ${clueModel.code} doesn't start in the bounds.`);
     }
 
     //  Make sure the clue is not too long.
     if (across) {
-      if ((clueModel.x + clueModel.totalLength) > model.width) {
+      if (clueModel.x + clueModel.totalLength > model.width) {
         throw new Error(`Clue ${clueModel.code} exceeds horizontal bounds.`);
       }
-    } else if ((clueModel.y + clueModel.totalLength) > model.height) {
+    } else if (clueModel.y + clueModel.totalLength > model.height) {
       throw new Error(`Clue ${clueModel.code} exceeds vertical bounds.`);
     }
 
@@ -98,28 +112,44 @@ function compileCrossword(crosswordDefinition) {
     for (let letter = 0; letter < clueModel.totalLength; letter += 1) {
       const cell = model.cells[x][y];
       cell.light = true;
-      cell[across ? 'acrossClue' : 'downClue'] = clueModel;
-      cell[across ? 'acrossClueLetterIndex' : 'downClueLetterIndex'] = letter;
+      cell[across ? "acrossClue" : "downClue"] = clueModel;
+      cell[across ? "acrossClueLetterIndex" : "downClueLetterIndex"] = letter;
       clueModel.cells.push(cell);
 
       //  Check if we need to add an answer terminator.
-      const [segment, index] = getAnswerSegment(clueModel.answerStructure, letter);
-      if (index === (segment.length - 1) && segment.terminator !== '') {
-        cell[clueModel.across ? 'acrossTerminator' : 'downTerminator'] = segment.terminator;
+      const [segment, index] = getAnswerSegment(
+        clueModel.answerStructure,
+        letter
+      );
+      if (index === segment.length - 1 && segment.terminator !== "") {
+        cell[clueModel.across ? "acrossTerminator" : "downTerminator"] =
+          segment.terminator;
       }
 
       //  If the clue has an answer we set it in the cell...
       if (clueModel.answer) {
         //  ...but only if it is not different to an existing answer.
-        if (cell.answer !== undefined && cell.answer !== ' ' && cell.answer !== clueModel.answer[letter]) {
-          throw new Error(`Clue ${clueModel.code} answer at (${x + 1}, ${y + 1}) is not coherent with previous clue (${cell.acrossClue.code}) answer.`);
+        if (
+          cell.answer !== undefined &&
+          cell.answer !== " " &&
+          cell.answer !== clueModel.answer[letter]
+        ) {
+          throw new Error(
+            `Clue ${clueModel.code} answer at (${x + 1}, ${
+              y + 1
+            }) is not coherent with previous clue (${
+              cell.acrossClue.code
+            }) answer.`
+          );
         }
         cell.answer = clueModel.answer[letter];
       }
 
       if (letter === 0) {
         if (cell.clueLabel && cell.clueLabel !== clueModel.number) {
-          throw new Error(`Clue ${clueModel.code} has a label which is inconsistent with another clue (${cell.acrossClue.code}).`);
+          throw new Error(
+            `Clue ${clueModel.code} has a label which is inconsistent with another clue (${cell.acrossClue.code}).`
+          );
         }
         cell.clueLabel = clueModel.number;
       }
@@ -141,23 +171,25 @@ function compileCrossword(crosswordDefinition) {
 
     //  Find the connected clues.
     clue.connectedClues = clue.connectedClueNumbers.map((connectedClue) => {
-      if (connectedClue.direction === 'across') {
-        return model.acrossClues.find((ac) => ac.number === connectedClue.number);
+      if (connectedClue.direction === "across") {
+        return model.acrossClues.find(
+          (ac) => ac.number === connectedClue.number
+        );
       }
-      if (connectedClue.direction === 'down') {
+      if (connectedClue.direction === "down") {
         return model.downClues.find((ac) => ac.number === connectedClue.number);
       }
-      return model.acrossClues.find((ac) => ac.number === connectedClue.number)
-        || model.downClues.find((ac) => ac.number === connectedClue.number);
+      return (
+        model.acrossClues.find((ac) => ac.number === connectedClue.number) ||
+        model.downClues.find((ac) => ac.number === connectedClue.number)
+      );
     });
 
     //  Rebuild the answer structure text.
-    clue.answerStructureText = `(${
-      [clue.answerStructureText]
-        .concat(clue.connectedClues.map((cc) => cc.answerStructureText))
-        .join(',')
-        .replace(/[()]/g, '')
-    })`;
+    clue.answerStructureText = `(${[clue.answerStructureText]
+      .concat(clue.connectedClues.map((cc) => cc.answerStructureText))
+      .join(",")
+      .replace(/[()]/g, "")})`;
 
     //  Each clue should know its parent 'master clue' as well as the next and
     //  previous clue segments.
@@ -167,7 +199,7 @@ function compileCrossword(crosswordDefinition) {
       if (clueSegmentIndex > 0) {
         cs.previousClueSegment = clueSegments[clueSegmentIndex - 1];
       }
-      if (clueSegmentIndex < (clueSegments.length - 1)) {
+      if (clueSegmentIndex < clueSegments.length - 1) {
         cs.nextClueSegment = clueSegments[clueSegmentIndex + 1];
       }
       [cs.parentClue] = clueSegments;
@@ -175,7 +207,9 @@ function compileCrossword(crosswordDefinition) {
     });
 
     //  Create the master clue label.
-    clue.clueLabel = `${[clue.number].concat(clue.connectedClues.map((cc) => cc.number)).join(',')}.`;
+    clue.clueLabel = `${[clue.number]
+      .concat(clue.connectedClues.map((cc) => cc.number))
+      .join(",")}.`;
 
     //  The connected clues need no answer structure, an indicator they are
     //  connected clues and a back link to the master clue.

--- a/src/compile-crossword.specs.js
+++ b/src/compile-crossword.specs.js
@@ -8,7 +8,7 @@ describe("model generation", () => {
     expect(() => {
       compileCrossword();
     }).to.throw(
-      "The Crossword must be initialised with a crossword definition."
+      "The Crossword must be initialised with a crossword definition.",
     );
   });
 
@@ -20,7 +20,7 @@ describe("model generation", () => {
     expect(crosswordModel.width).to.eql(quiptic89.width);
     expect(crosswordModel.height).to.eql(quiptic89.height);
     expect(crosswordModel.acrossClues.length).to.eql(
-      quiptic89.acrossClues.length
+      quiptic89.acrossClues.length,
     );
     expect(crosswordModel.downClues.length).to.eql(quiptic89.downClues.length);
   });
@@ -38,7 +38,7 @@ describe("model generation", () => {
     //  The following elements are parsed from the clue text.
     expect(modelClue.number).to.eql(1);
     expect(modelClue.clueText).to.eql(
-      "Conspicuous influence exerted by active troops "
+      "Conspicuous influence exerted by active troops ",
     );
   });
 
@@ -137,7 +137,7 @@ describe("model generation", () => {
     expect(() => {
       compileCrossword(crosswordDefinition);
     }).to.throw(
-      "Clue 1d answer at (3, 3) is not coherent with previous clue (1a) answer."
+      "Clue 1d answer at (3, 3) is not coherent with previous clue (1a) answer.",
     );
   });
 

--- a/src/compile-crossword.specs.js
+++ b/src/compile-crossword.specs.js
@@ -1,25 +1,31 @@
-const { expect } = require('chai');
-const compileCrossword = require('./compile-crossword');
-const quiptic89 = require('./test-crosswords/quiptic89.json');
-const albreich4 = require('./test-crosswords/albreich_4.json');
+const { expect } = require("chai");
+const compileCrossword = require("./compile-crossword");
+const quiptic89 = require("./test-crosswords/quiptic89.json");
+const albreich4 = require("./test-crosswords/albreich_4.json");
 
-describe('model generation', () => {
-  it('should fail if no definition is provided', () => {
-    expect(() => { compileCrossword(); }).to.throw('The Crossword must be initialised with a crossword definition.');
+describe("model generation", () => {
+  it("should fail if no definition is provided", () => {
+    expect(() => {
+      compileCrossword();
+    }).to.throw(
+      "The Crossword must be initialised with a crossword definition."
+    );
   });
 
-  it('should provide basic details of the crossword in the model', () => {
+  it("should provide basic details of the crossword in the model", () => {
     //  Generate the crossword model.
     const crosswordModel = compileCrossword(quiptic89);
 
     //  Check the width, height and clues.
     expect(crosswordModel.width).to.eql(quiptic89.width);
     expect(crosswordModel.height).to.eql(quiptic89.height);
-    expect(crosswordModel.acrossClues.length).to.eql(quiptic89.acrossClues.length);
+    expect(crosswordModel.acrossClues.length).to.eql(
+      quiptic89.acrossClues.length
+    );
     expect(crosswordModel.downClues.length).to.eql(quiptic89.downClues.length);
   });
 
-  it('should provide clues in the model', () => {
+  it("should provide clues in the model", () => {
     const crosswordModel = compileCrossword(quiptic89);
 
     const definitionClue = quiptic89.acrossClues[0];
@@ -31,30 +37,38 @@ describe('model generation', () => {
 
     //  The following elements are parsed from the clue text.
     expect(modelClue.number).to.eql(1);
-    expect(modelClue.clueText).to.eql('Conspicuous influence exerted by active troops ');
+    expect(modelClue.clueText).to.eql(
+      "Conspicuous influence exerted by active troops "
+    );
   });
 
-  it('should fail if the bounds of the crossword are invalid', () => {
-    const expectedError = 'The crossword bounds are invalid.';
+  it("should fail if the bounds of the crossword are invalid", () => {
+    const expectedError = "The crossword bounds are invalid.";
 
     let crosswordDefinition = {
       width: null,
     };
-    expect(() => { compileCrossword(crosswordDefinition); }).to.throw(expectedError);
+    expect(() => {
+      compileCrossword(crosswordDefinition);
+    }).to.throw(expectedError);
 
     crosswordDefinition = {
       width: 3,
       height: -1,
     };
-    expect(() => { compileCrossword(crosswordDefinition); }).to.throw(expectedError);
+    expect(() => {
+      compileCrossword(crosswordDefinition);
+    }).to.throw(expectedError);
 
     crosswordDefinition = {
       height: -2,
     };
-    expect(() => { compileCrossword(crosswordDefinition); }).to.throw(expectedError);
+    expect(() => {
+      compileCrossword(crosswordDefinition);
+    }).to.throw(expectedError);
   });
 
-  it('should fail if a clue exceeds the bounds of the crossword', () => {
+  it("should fail if a clue exceeds the bounds of the crossword", () => {
     const crosswordDefinition = {
       width: 10,
       height: 10,
@@ -66,52 +80,68 @@ describe('model generation', () => {
       {
         x: 3,
         y: 1,
-        clue: '3. Clue (12)',
+        clue: "3. Clue (12)",
       },
     ];
-    expect(() => { compileCrossword(crosswordDefinition); }).to.throw('Clue 3a exceeds horizontal bounds.');
+    expect(() => {
+      compileCrossword(crosswordDefinition);
+    }).to.throw("Clue 3a exceeds horizontal bounds.");
 
     crosswordDefinition.acrossClues = [];
     crosswordDefinition.downClues = [
       {
         x: 1,
         y: 3,
-        clue: '3. Clue (3,1,5)',
+        clue: "3. Clue (3,1,5)",
       },
     ];
-    expect(() => { compileCrossword(crosswordDefinition); }).to.throw('Clue 3d exceeds vertical bounds.');
+    expect(() => {
+      compileCrossword(crosswordDefinition);
+    }).to.throw("Clue 3d exceeds vertical bounds.");
 
     crosswordDefinition.acrossClues = [
       {
         x: 3,
         y: -1,
-        clue: '3. Clue (12)',
+        clue: "3. Clue (12)",
       },
     ];
-    expect(() => { compileCrossword(crosswordDefinition); }).to.throw("Clue 3a doesn't start in the bounds.");
+    expect(() => {
+      compileCrossword(crosswordDefinition);
+    }).to.throw("Clue 3a doesn't start in the bounds.");
   });
 
-  it('should validate the coherence of a clue if the answers are provided', () => {
+  it("should validate the coherence of a clue if the answers are provided", () => {
     //  This is incoherent - (3,3) is both A and P.
     const crosswordDefinition = {
       width: 10,
       height: 10,
       acrossClues: [
         {
-          clue: '1. Red or green fruit (5)', x: 3, y: 3, answer: 'APPLE',
+          clue: "1. Red or green fruit (5)",
+          x: 3,
+          y: 3,
+          answer: "APPLE",
         },
       ],
       downClues: [
         {
-          clue: '1. Fuzzy fruit (5)', x: 3, y: 3, answer: 'PEACH',
+          clue: "1. Fuzzy fruit (5)",
+          x: 3,
+          y: 3,
+          answer: "PEACH",
         },
       ],
     };
 
-    expect(() => { compileCrossword(crosswordDefinition); }).to.throw('Clue 1d answer at (3, 3) is not coherent with previous clue (1a) answer.');
+    expect(() => {
+      compileCrossword(crosswordDefinition);
+    }).to.throw(
+      "Clue 1d answer at (3, 3) is not coherent with previous clue (1a) answer."
+    );
   });
 
-  it('should correctly construct non-linear clues', () => {
+  it("should correctly construct non-linear clues", () => {
     //  Non-linear clues are clues which have an answer that does fit in a
     //  single contiguous block, but instead is split into multiple sections.
     const crossword = compileCrossword(albreich4);
@@ -126,7 +156,7 @@ describe('model generation', () => {
 
     //  Make sure the connected clues are set.
     expect(clue4down.connectedClues).to.eql([clue21across]);
-    expect(clue4down.answerStructureText).to.eql('(9,3,5)');
-    expect(clue4down.clueLabel).to.eql('4,21.');
+    expect(clue4down.answerStructureText).to.eql("(9,3,5)");
+    expect(clue4down.clueLabel).to.eql("4,21.");
   });
 });

--- a/src/crossworddom.js
+++ b/src/crossworddom.js
@@ -315,14 +315,14 @@ class CrosswordDOM {
           eventCell.acrossClue.answer = setLetter(
             eventCell.acrossClue.answer,
             eventCell.acrossClueLetterIndex,
-            character
+            character,
           );
         }
         if (eventCell.downClue) {
           eventCell.downClue.answer = setLetter(
             eventCell.downClue.answer,
             eventCell.downClueLetterIndex,
-            character
+            character,
           );
         }
       }
@@ -501,7 +501,7 @@ class CrosswordDOM {
         if (cell.light) {
           removeClass(
             self.#cellMap.getCellElement(cell).querySelector("input"),
-            "active"
+            "active",
           );
         }
       });
@@ -516,7 +516,7 @@ class CrosswordDOM {
       clue.cells.forEach((cell) => {
         addClass(
           self.#cellMap.getCellElement(cell).querySelector("input"),
-          "active"
+          "active",
         );
       });
     });

--- a/src/crossworddom.js
+++ b/src/crossworddom.js
@@ -372,23 +372,23 @@ class CrosswordDOM {
               .getCellElement(eventCell.crossword.cells[x - 1][y])
               .querySelector("input")
               .focus();
-            } else {
-              // Can we go to previous segment in clue?
-              const currentIndex =
-                eventCell.acrossClue === clue
-                  ? eventCell.acrossClueLetterIndex
-                  : eventCell.downClueLetterIndex;
-              trace(`current cell index: ${currentIndex}`);
-              const previousIndex = currentIndex - 1;
-              //  If we are at the start of the clue and we have a previous segment, select it.
-              if (previousIndex === -1 && clue.previousClueSegment) {
-                trace("Focussing prev answer segment last cell");
-                last(clue.previousClueSegment.cells).cellElement
-                  .querySelector("input")
-                  .focus();
-              }
+          } else {
+            // Can we go to previous segment in clue?
+            const currentIndex =
+              eventCell.acrossClue === clue
+                ? eventCell.acrossClueLetterIndex
+                : eventCell.downClueLetterIndex;
+            trace(`current cell index: ${currentIndex}`);
+            const previousIndex = currentIndex - 1;
+            //  If we are at the start of the clue and we have a previous segment, select it.
+            if (previousIndex === -1 && clue.previousClueSegment) {
+              trace("Focussing prev answer segment last cell");
+              last(clue.previousClueSegment.cells)
+                .cellElement.querySelector("input")
+                .focus();
             }
-            break;
+          }
+          break;
         case 38: // up
           //  If we can go up, go up.
           if (
@@ -400,22 +400,22 @@ class CrosswordDOM {
               .getCellElement(eventCell.crossword.cells[x][y - 1])
               .querySelector("input")
               .focus();
-            } else {
-              // Can we go to previous segment in clue?
-              const currentIndex =
-                eventCell.acrossClue === clue
-                  ? eventCell.acrossClueLetterIndex
-                  : eventCell.downClueLetterIndex;
-              trace(`current cell index: ${currentIndex}`);
-              const previousIndex = currentIndex - 1;
-              //  If we are at the start of the clue and we have a previous segment, select it.
-              if (previousIndex === -1 && clue.previousClueSegment) {
-                trace("Focussing prev answer segment last cell");
-                last(clue.previousClueSegment.cells).cellElement
-                  .querySelector("input")
-                  .focus();
-              }
+          } else {
+            // Can we go to previous segment in clue?
+            const currentIndex =
+              eventCell.acrossClue === clue
+                ? eventCell.acrossClueLetterIndex
+                : eventCell.downClueLetterIndex;
+            trace(`current cell index: ${currentIndex}`);
+            const previousIndex = currentIndex - 1;
+            //  If we are at the start of the clue and we have a previous segment, select it.
+            if (previousIndex === -1 && clue.previousClueSegment) {
+              trace("Focussing prev answer segment last cell");
+              last(clue.previousClueSegment.cells)
+                .cellElement.querySelector("input")
+                .focus();
             }
+          }
           break;
         case 39: // right
           //  If we can go right, go right.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,14 +1,25 @@
 //  Lightweight helper functions.
 function removeClass(element, className) {
-  const expression = new RegExp(`(?:^|\\s)${className}(?!\\S)`, 'g');
-  element.className = element.className.replace(expression, '');
+  const expression = new RegExp(`(?:^|\\s)${className}(?!\\S)`, "g");
+  element.className = element.className.replace(expression, "");
 }
 
 function addClass(element, className) {
   element.className += ` ${className}`;
 }
 
+function first(array) {
+  // If array is not nullish, return first element
+  return array ? array[0] : null;
+}
+
+function last(array) {
+  // If array is not nullish, return last element
+  return array ? array.at(-1) : null;
+}
 module.exports = {
   removeClass,
   addClass,
+  first,
+  last,
 };

--- a/src/index.specs.js
+++ b/src/index.specs.js
@@ -1,8 +1,8 @@
-const { expect } = require('chai');
-const index = require('./index');
+const { expect } = require("chai");
+const index = require("./index");
 
-describe('index', () => {
-  it('should export a compileCrossword function', () => {
-    expect(index.compileCrossword).to.be.a('Function');
+describe("index", () => {
+  it("should export a compileCrossword function", () => {
+    expect(index.compileCrossword).to.be.a("Function");
   });
 });


### PR DESCRIPTION
# nfc
- reformatting changes by **prettier**. Sorry - makes it hard to find logical changes! Are you using **prettier** @dwmkerr? If so we should add to the project with a config file for consistency.
# feature
- add support for multi-segment clue navigation to arrow keys - jump to next/prev segment. Add/reinstate `first`, `last` array helpers to `helpers.js`
# doc
- add documentation for multi-word answers and multi-segment clues.