### PR TITLE
use css variables for grid size

### DIFF
--- a/src/crossword-controller.mjs
+++ b/src/crossword-controller.mjs
@@ -98,6 +98,11 @@ class CrosswordController {
     this.#domCluesParentElement = domCluesParentElement;
     //  Build the DOM for the crossword grid.
     this.#crosswordGridView = this.#document.createElement('div');
+
+    // set the grid size variables, used as part of the css-grid styling
+    this.#crosswordGridView.style.setProperty('--row-count', this.#crosswordModel.height.toString())
+    this.#crosswordGridView.style.setProperty('--column-count', this.#crosswordModel.width.toString())
+
     addClass(this.#crosswordGridView, 'crossword-grid');
 
     // Build the DOM for the crossword clues.

--- a/style/crosswords.less
+++ b/style/crosswords.less
@@ -1,10 +1,16 @@
 @import url('../style/cwdimensions.less');
 @import url('../style/cwcolors.less');
 
+:root {
+  /* default grid size, this is overriden in JS */
+  --row-count: 15;
+  --column-count: 15;
+}
+
 @media screen and (max-width: 391px) {
   .crossword-grid {
-    grid-template-rows: repeat(@row-count, @grid-cell-size-0);
-    grid-template-columns: repeat(@column-count, @grid-cell-size-0);
+    grid-template-rows: repeat(var(--row-count), @grid-cell-size-0);
+    grid-template-columns: repeat(var(--column-count), @grid-cell-size-0);
 
     input {
       font-size: @letter-size-0;
@@ -29,8 +35,8 @@
 
 @media screen and (min-width: 392px) and (max-width: 555px) {
   .crossword-grid {
-    grid-template-rows: repeat(@row-count, @grid-cell-size-1);
-    grid-template-columns: repeat(@column-count, @grid-cell-size-1);
+    grid-template-rows: repeat(var(--row-count), @grid-cell-size-1);
+    grid-template-columns: repeat(var(--column-count), @grid-cell-size-1);
 
     input {
       font-size: @letter-size-1;
@@ -55,8 +61,8 @@
 
 @media screen and (min-width: 556px) {
   .crossword-grid {
-    grid-template-rows: repeat(@row-count, @grid-cell-size-2);
-    grid-template-columns: repeat(@column-count, @grid-cell-size-2);
+    grid-template-rows: repeat(var(--row-count), @grid-cell-size-2);
+    grid-template-columns: repeat(var(--column-count), @grid-cell-size-2);
 
     input {
       font-size: @letter-size-2;

--- a/style/cwdimensions.less
+++ b/style/cwdimensions.less
@@ -1,7 +1,3 @@
-// Grid dimensions
-@row-count: 15;
-@column-count: 15;
-
 //// Crossword grid sizes
 
 @grid-line-size: 1px;


### PR DESCRIPTION
Fix a bug, possibly introduced by https://github.com/dwmkerr/crosswords-js/pull/36 (not sure though, I didn't use the version before that pull request).

#36 introduced less, which has variables, but the variables are still "static" - they don't know the dimensions of the actual crossword being rendered, because that's dynamic. CSS variables are designed for exactly this sort of thing. Less variables are still useful when dynamic values aren't needed (i.e. just for organization/developer experience) - so I didn't touch the other variables. Here's what a 9x9 crossword looks like without this change:

<img width="623" alt="image" src="https://github.com/dwmkerr/crosswords-js/assets/15040698/dcf91c23-8910-4548-985e-cea29aa0a2df">

---

And here's what it looks like with this change (this is what it's supposed to look like!!):

<img width="374" alt="image" src="https://github.com/dwmkerr/crosswords-js/assets/15040698/3e07d3e1-5040-412a-a1b8-5b6f7456017d">

Note: css variables are supported pretty much everywhere, but not IE 11 or Opera Mini: https://caniuse.com/css-variables