### PR TITLE
add husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run build
+git add dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-prettier": "^5.0.0",
         "esm": "^3.2.25",
+        "husky": "^8.0.3",
         "ignore-styles": "^5.0.1",
         "less": "^4.1.3",
         "less-loader": "^11.1.0",
@@ -5057,6 +5058,21 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^5.0.0",
     "esm": "^3.2.25",
+    "husky": "^8.0.3",
     "ignore-styles": "^5.0.1",
     "less": "^4.1.3",
     "less-loader": "^11.1.0",
@@ -57,7 +58,8 @@
     "test:cov": "nyc mocha",
     "test:debug": "mocha --inspect-brk -w",
     "test": "mocha",
-    "update": "bin/update-package.sh"
+    "update": "bin/update-package.sh",
+    "prepare": "husky install"
   },
   "keywords": [
     "crossword"


### PR DESCRIPTION
This will run the build script before every commit, and add the `dist` folder to it - no more out-of-date `dist/`.

Note: husky will install the relevant git hooks after `npm install` (via the `prepare` script), as documented here: https://typicode.github.io/husky/getting-started.html

I'm not sure if others have existing hooks - if they'd be beneficial to all they could be added to the `pre-commit` script, or if not there may be a way to merge husky hooks with user-defined ones.